### PR TITLE
Revert "perf: import every Material Variant at once"

### DIFF
--- a/Editor/Allocator/ResourceAllocator.cs
+++ b/Editor/Allocator/ResourceAllocator.cs
@@ -71,6 +71,7 @@ namespace ResoniteImportHelper.Allocator
 
             Debug.Log($"Importer: {AssetDatabase.GetImporterType(basePath)}");
 
+            Debug.Assert(!AssetDatabase.GUIDFromAssetPath(AssetDatabase.GetAssetPath(persistent)).Empty(), "object must be serialized on exit.");
             return persistent;
         }
 

--- a/Editor/Transform/Environment/LilToon/LilToonHandler.cs
+++ b/Editor/Transform/Environment/LilToon/LilToonHandler.cs
@@ -40,22 +40,13 @@ namespace ResoniteImportHelper.Transform.Environment.LilToon
             return;
 #endif
             Profiler.BeginSample("LilToonHandler.PerformInlineTransform");
-            try
+            foreach (var renderer in GameObjectRecurseUtility.GetChildrenRecursive(modifiableRoot)
+                         .Select(o => 
+                             o.TryGetComponent(out SkinnedMeshRenderer smr) ? smr : null
+                         ).Where(o => o != null))
             {
-                AssetDatabase.StartAssetEditing();
-                foreach (var renderer in GameObjectRecurseUtility.GetChildrenRecursive(modifiableRoot)
-                             .Select(o => 
-                                 o.TryGetComponent(out SkinnedMeshRenderer smr) ? smr : null
-                             ).Where(o => o != null))
-                {
-                    renderer.sharedMaterials = renderer.sharedMaterials.Select(RewriteInline).ToArray();
-                }
+                renderer.sharedMaterials = renderer.sharedMaterials.Select(RewriteInline).ToArray();
             }
-            finally
-            {
-                AssetDatabase.StopAssetEditing();
-            }
-            
             Profiler.EndSample();
         }
 


### PR DESCRIPTION
This reverts commit a8bd15c.

close #91

アロケーターが確保したテクスチャが自動インポート抑止によりシリアライズされず、ゼロGUIDになってホワイトテクスチャバグを誘発していた。